### PR TITLE
[feature] Spigot 서버 월드를 열 수 있도록 함

### DIFF
--- a/src/main/kotlin/composable/editor/NbtEditor.kt
+++ b/src/main/kotlin/composable/editor/NbtEditor.kt
@@ -21,7 +21,6 @@ import doodler.doodle.structures.ReadonlyDoodle
 import doodler.doodle.structures.TagDoodle
 import doodler.editor.NbtEditor
 import doodler.editor.states.NbtEditorState
-import doodler.logging.DoodlerLogger
 import doodler.minecraft.structures.WorldSpecification
 import doodler.theme.DoodlerTheme
 import doodler.types.Provider
@@ -36,8 +35,6 @@ fun BoxScope.NbtEditor(
     editor: NbtEditor,
     worldSpec: WorldSpecification? = null
 ) {
-
-    DoodlerLogger.recomposition("NbtEditor")
 
     val coroutine = rememberCoroutineScope()
 

--- a/src/main/kotlin/composable/editor/world/Tabs.kt
+++ b/src/main/kotlin/composable/editor/world/Tabs.kt
@@ -28,11 +28,13 @@ import doodler.editor.NbtEditor
 import doodler.editor.states.WorldEditorState
 import doodler.extension.toUUID
 import doodler.minecraft.structures.WorldSpecification
+import doodler.minecraft.structures.WorldType
 import doodler.theme.DoodlerTheme
 import doodler.types.BooleanProvider
 import doodler.unit.ddp
 import doodler.unit.dsp
 import kotlinx.coroutines.CoroutineScope
+import java.io.File
 
 
 @Composable
@@ -168,6 +170,24 @@ fun EditorTab(
                     fontSize = 7.5.dsp
                 )
                 Spacer(modifier = Modifier.width(2.7.ddp))
+            }
+
+            if (worldSpec.type != WorldType.Vanilla && editor is NbtEditor && editor.name == "level.dat") {
+                val path = when (File(editor.state.file.absolutePath).parentFile.name) {
+                    worldSpec.name -> "overworld/"
+                    "${worldSpec.name}_nether" -> "nether/"
+                    "${worldSpec.name}_the_end" -> "the_end/"
+                    else -> null
+                }
+
+                if (path != null) {
+                    Text(
+                        text = path,
+                        color = DoodlerTheme.Colors.Editor.TabPath,
+                        fontSize = 7.5.dsp
+                    )
+                    Spacer(modifier = Modifier.width(2.7.ddp))
+                }
             }
 
             Text(

--- a/src/main/kotlin/composable/intro/Intro.kt
+++ b/src/main/kotlin/composable/intro/Intro.kt
@@ -24,6 +24,7 @@ import doodler.application.structure.DoodlerEditorType
 import doodler.application.structure.IntroDoodlerWindow
 import doodler.extension.ellipsisLast
 import doodler.extension.ellipsisStart
+import doodler.extension.fileOrNull
 import doodler.local.Recent
 import doodler.local.UserSavedLocalState
 import doodler.theme.DoodlerTheme
@@ -324,9 +325,11 @@ fun WorldRecentItem(
 
     val exists by remember(data.path) { mutableStateOf(File(data.path).exists()) }
 
-    val file = remember(data.path) { File("${data.path}/icon.png") }
+    val file = remember(data.path) {
+        fileOrNull("${data.path}/icon.png") ?: fileOrNull("${data.path}/server-icon.png")
+    }
 
-    val worldIconPainter = remember(file) { if (file.exists()) ImageIO.read(file).toComposeImageBitmap() else null }
+    val worldIconPainter = remember(file) { if (file != null) ImageIO.read(file).toComposeImageBitmap() else null }
     val fallbackWorldIcon = painterResource("/icons/intro/open_new_world.png")
 
     val contentDescription = remember { "world preview icon of ${data.name}" }

--- a/src/main/kotlin/composable/selector/Selector.kt
+++ b/src/main/kotlin/composable/selector/Selector.kt
@@ -51,6 +51,8 @@ private val File.typeId get() = if (isDirectory && !isFile) -1 else if (isFile) 
 private fun File.validateAs(type: DoodlerEditorType): File? {
     when(type) {
         DoodlerEditorType.World -> {
+            if (File("${this.absolutePath}/server.properties").exists()) return this
+
             val level = File("${this.absolutePath}/level.dat")
             if (!level.exists()) return null
 

--- a/src/main/kotlin/doodler/application/state/DoodlerAppState.kt
+++ b/src/main/kotlin/doodler/application/state/DoodlerAppState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import doodler.application.structure.*
+import doodler.minecraft.structures.WorldSpecification
 import java.io.File
 
 @Stable
@@ -39,17 +40,26 @@ class DoodlerAppState(
         windows.addAll(oldWindows.map { it.copy() }.sortedBy { if (it is IntroDoodlerWindow) 1 else 0 })
     }
 
-    fun sketchEditor(title: String, type: DoodlerEditorType, file: File): Boolean {
-        val that = when (type) {
-            DoodlerEditorType.World -> WorldEditorDoodlerWindow(
-                title = "doodler - ${title}[${type.name}]",
-                path = file.absolutePath,
-            )
-            DoodlerEditorType.Standalone -> StandaloneEditorDoodlerWindow(
-                title = "doodler - ${title}[${type.name}]",
-                file = file
-            )
-        }
+    fun sketchWorldEditor(title: String, path: String, worldSpec: WorldSpecification): Boolean {
+        val that = WorldEditorDoodlerWindow(
+            title = "doodler - ${title}[${DoodlerEditorType.World.name}]",
+            path = path,
+            worldSpec = worldSpec
+        )
+
+        return sketchEditor(that)
+    }
+
+    fun sketchStandaloneEditor(title: String, file: File): Boolean {
+        val that = StandaloneEditorDoodlerWindow(
+            title = "doodler - ${title}[${DoodlerEditorType.World.name}]",
+            file = file
+        )
+
+        return sketchEditor(that)
+    }
+
+    fun sketchEditor(that: EditorDoodlerWindow): Boolean {
         if (windows.any { it is EditorDoodlerWindow && it.path == that.path })
             return false
 

--- a/src/main/kotlin/doodler/application/structure/DoodlerWindow.kt
+++ b/src/main/kotlin/doodler/application/structure/DoodlerWindow.kt
@@ -73,10 +73,11 @@ class WorldEditorDoodlerWindow(
     title: String,
     path: String,
     position: WindowPosition = WindowPosition(Alignment.Center),
-    override val editorState: WorldEditorState = WorldEditorState(manager = EditorManager(), worldSpec = WorldSpecification(path))
+    val worldSpec: WorldSpecification,
+    override val editorState: WorldEditorState = WorldEditorState(manager = EditorManager(), worldSpec = worldSpec)
 ): EditorDoodlerWindow(title, position, DoodlerEditorType.World, path) {
 
-    override fun copy() = WorldEditorDoodlerWindow(title, path, state.position, editorState)
+    override fun copy() = WorldEditorDoodlerWindow(title, path, state.position, worldSpec, editorState)
 
 }
 

--- a/src/main/kotlin/doodler/extension/File.kt
+++ b/src/main/kotlin/doodler/extension/File.kt
@@ -5,3 +5,5 @@ import java.io.File
 fun File.safeListFiles(): List<File> {
     return this.let { if (!it.exists()) null else it.listFiles()?.toList() } ?: listOf()
 }
+
+fun fileOrNull(path: String) = File(path).let { if (it.exists()) it else null }

--- a/src/main/kotlin/doodler/extension/File.kt
+++ b/src/main/kotlin/doodler/extension/File.kt
@@ -1,0 +1,7 @@
+package doodler.extension
+
+import java.io.File
+
+fun File.safeListFiles(): List<File> {
+    return this.let { if (!it.exists()) null else it.listFiles()?.toList() } ?: listOf()
+}

--- a/src/main/kotlin/doodler/minecraft/WorldUtils.kt
+++ b/src/main/kotlin/doodler/minecraft/WorldUtils.kt
@@ -1,8 +1,7 @@
 package doodler.minecraft
 
-import doodler.minecraft.structures.WorldDimension
-import doodler.minecraft.structures.WorldDimensionHierarchy
-import doodler.minecraft.structures.WorldHierarchy
+import doodler.extension.safeListFiles
+import doodler.minecraft.structures.*
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -10,7 +9,7 @@ class WorldUtils {
 
     companion object {
 
-        fun loadVanilla(path: String): WorldHierarchy {
+        fun loadVanilla(path: String): VanillaWorldHierarchy {
             val world = File(path)
 
             if (!world.exists()) throw FileNotFoundException()
@@ -18,41 +17,80 @@ class WorldUtils {
             val nether = "$path/${WorldDimension.Nether.ident}"
             val theEnd = "$path/${WorldDimension.TheEnd.ident}"
 
-            return (
-                WorldHierarchy(
-                    File("$path/icon.png"),
-                    File("$path/level.dat"),
-                    File("$path/advancements").listIfExists(),
-                    File("$path/stats").listIfExists(),
-                    File("$path/playerdata").listIfExists(),
-                    WorldDimensionHierarchy(
-                        File("$path/region").listIfExists(),
-                        File("$path/entities").listIfExists(),
-                        File("$path/poi").listIfExists(),
-                        File("$path/data").listIfExists()
-                    ),
-                    WorldDimensionHierarchy(
-                        File("$nether/region").listIfExists(),
-                        File("$nether/entities").listIfExists(),
-                        File("$nether/poi").listIfExists(),
-                        File("$nether/data").listIfExists()
-                    ),
-                    WorldDimensionHierarchy(
-                        File("$theEnd/region").listIfExists(),
-                        File("$theEnd/entities").listIfExists(),
-                        File("$theEnd/poi").listIfExists(),
-                        File("$theEnd/data").listIfExists()
-                    )
+            return VanillaWorldHierarchy(
+                File("$path/level.dat"),
+                File("$path/icon.png"),
+                File("$path/advancements").safeListFiles(),
+                File("$path/stats").safeListFiles(),
+                File("$path/playerdata").safeListFiles(),
+                WorldDimensionHierarchy(
+                    File("$path/region").safeListFiles(),
+                    File("$path/entities").safeListFiles(),
+                    File("$path/poi").safeListFiles(),
+                    File("$path/data").safeListFiles()
+                ),
+                WorldDimensionHierarchy(
+                    File("$nether/region").safeListFiles(),
+                    File("$nether/entities").safeListFiles(),
+                    File("$nether/poi").safeListFiles(),
+                    File("$nether/data").safeListFiles()
+                ),
+                WorldDimensionHierarchy(
+                    File("$theEnd/region").safeListFiles(),
+                    File("$theEnd/entities").safeListFiles(),
+                    File("$theEnd/poi").safeListFiles(),
+                    File("$theEnd/data").safeListFiles()
                 )
             )
         }
 
-        fun loadServer(path: String): WorldHierarchy {
-            TODO("Not Implemented")
-        }
+        fun loadServer(path: String): SpigotServerWorldHierarchy {
+            val world = File(path)
 
-        private fun File.listIfExists(): List<File> {
-            return this.let { if (!it.exists()) null else it.listFiles()?.toList() } ?: listOf()
+            if (!world.exists()) throw FileNotFoundException()
+
+            val serverProperties = File("$path/server.properties")
+                .readText()
+                .trim()
+                .split("\n")
+                .filter { !it.startsWith("#") }
+                .associate { record -> record.split("=").let { it[0] to it[1] } }
+
+            val levelName = serverProperties.getValue("level-name")
+
+            val overworld = "$path/$levelName"
+            val nether = "$path/${levelName}_${WorldDimension.Nether.displayName}"
+            val theEnd = "$path/${levelName}_${WorldDimension.TheEnd.displayName}"
+
+            return SpigotServerWorldHierarchy(
+                mapOf(
+                    WorldDimension.Overworld to File("$overworld/level.dat"),
+                    WorldDimension.Nether to File("$nether/level.dat"),
+                    WorldDimension.TheEnd to File("$theEnd/level.dat")
+                ),
+                File("$path/server-icon.png"),
+                File("$overworld/advancements").safeListFiles(),
+                File("$overworld/stats").safeListFiles(),
+                File("$overworld/playerdata").safeListFiles(),
+                WorldDimensionHierarchy(
+                    File("$overworld/region").safeListFiles(),
+                    File("$overworld/entities").safeListFiles(),
+                    File("$overworld/poi").safeListFiles(),
+                    File("$overworld/data").safeListFiles()
+                ),
+                WorldDimensionHierarchy(
+                    File("$nether/region").safeListFiles(),
+                    File("$nether/entities").safeListFiles(),
+                    File("$nether/poi").safeListFiles(),
+                    File("$nether/data").safeListFiles()
+                ),
+                WorldDimensionHierarchy(
+                    File("$theEnd/region").safeListFiles(),
+                    File("$theEnd/entities").safeListFiles(),
+                    File("$theEnd/poi").safeListFiles(),
+                    File("$theEnd/data").safeListFiles()
+                )
+            )
         }
 
     }

--- a/src/main/kotlin/doodler/minecraft/WorldUtils.kt
+++ b/src/main/kotlin/doodler/minecraft/WorldUtils.kt
@@ -10,7 +10,7 @@ class WorldUtils {
 
     companion object {
 
-        fun load(path: String): WorldHierarchy {
+        fun loadVanilla(path: String): WorldHierarchy {
             val world = File(path)
 
             if (!world.exists()) throw FileNotFoundException()
@@ -45,6 +45,10 @@ class WorldUtils {
                     )
                 )
             )
+        }
+
+        fun loadServer(path: String): WorldHierarchy {
+            TODO("Not Implemented")
         }
 
         private fun File.listIfExists(): List<File> {

--- a/src/main/kotlin/doodler/minecraft/structures/WorldStructures.kt
+++ b/src/main/kotlin/doodler/minecraft/structures/WorldStructures.kt
@@ -104,7 +104,13 @@ class WorldSpecification (
         val NetworkScope = CoroutineScope(Dispatchers.IO)
     }
 
-    val tree: WorldHierarchy = WorldUtils.load(worldPath)
+    val type: WorldType = type(worldPath)
+
+    val tree: WorldHierarchy =
+        when (type){
+          WorldType.Vanilla -> WorldUtils.loadVanilla(worldPath)
+          WorldType.SpigotServer -> WorldUtils.loadServer(worldPath)
+        }
 
     private var levelInfo by mutableStateOf(DatWorker.read(tree.level.readBytes()))
 
@@ -140,6 +146,19 @@ class WorldSpecification (
         levelInfo = DatWorker.read(tree.level.readBytes())
     }
 
+    private fun type(path: String): WorldType {
+        val file = File(path)
+        return if (file.list()?.contains("server.properties") == true) {
+            WorldType.SpigotServer
+        } else {
+            WorldType.Vanilla
+        }
+    }
+
+}
+
+enum class WorldType {
+    Vanilla, SpigotServer
 }
 
 sealed class WorldFileType


### PR DESCRIPTION
Spigot 서버를 열 수 있도록 했다.

- WorldSpecification의 초기화를 에디터의 상태가 생성될 때가 아닌 에디터의 윈도우가 생성되기 전에 수행하도록 했다.
  - 이는 열려는 월드의 타입에 따라 서로 다른 WorldSpecification을 만들도록 하기 위함
- WorldSpecification을 sealed class 로 바꾸고, VanillaWorldSpecification 과 SpigotServerWorldSpecification 으로 구현을 나눔
  - 이렇게 하면 나중에 Spigot 이 아닌 다른 서버도 비교적 쉽게 핸들링할 수 있음
- 각 월드 타입에 따라 WorldSpecification의 생성 구현을 분리하고, 그것을 정상적으로 UI에 표시할 수 있도록 함